### PR TITLE
fix: strip /en prefix from utterances issue-term to match existing comments

### DIFF
--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,7 +1,7 @@
 {{ $path := .RelPermalink }}
 {{ range .AllTranslations }}
   {{ if eq .Lang "en" }}
-    {{ $path = .RelPermalink }}
+    {{ $path = .RelPermalink | strings.TrimPrefix "/en" }}
   {{ end }}
 {{ end }}
 <script


### PR DESCRIPTION
Utterances matches comments to GitHub issues by pathname. English posts
have RelPermalink like /en/blog/slug/, but existing issues were created
when users visited root paths /blog/slug/. Stripping the /en prefix
restores the match.

https://claude.ai/code/session_01TRdjTUJu6XK6ms1UBGEDkF