### PR TITLE
Fix redacción en posts en español

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,37 @@ Translations are **localizations**, not literal translations. Each version must 
 7. **Technical terms stay in English** — `scrypt`, `hashcat`, `exploit`, `brute force`, `CVE`, `AES`, `adb` are not translated. App names, protocol names, and CLI commands are never localized.
 8. **Proofread for naturalness** — after translating, re-read each sentence and ask: "Would someone from NYC/Tokyo/Beijing actually say this?" If not, rewrite it.
 
+### Anti-AI patterns (applies to all languages)
+
+AI-generated text has recognizable tells. Any of these in a draft is a red flag — rewrite the sentence.
+
+**Universal**
+- No em dashes (—). Use a comma, a period, or restructure the sentence. `"X — which is important — because"` → `"X, which matters because"` or just split into two sentences.
+- No AI filler transitions: "furthermore", "moreover", "additionally", "it's worth noting", "in conclusion", "to summarize", "it is important to highlight", "it's important to remember"
+- No formulaic openers: don't start multiple paragraphs with the same structure
+- Active voice by default. Passive only when the agent genuinely doesn't matter.
+- Don't over-explain. If something is obvious from context, cut it.
+- Vary sentence length. AI defaults to uniform medium-length sentences. Mix short punchy ones with longer ones.
+- No unnatural symmetry. AI loves balanced parallel structures that humans don't naturally write.
+
+**Spanish**
+- No: "es importante destacar", "cabe señalar", "en este sentido", "a su vez", "asimismo", "por ende", "no obstante", "en definitiva", "cabe mencionar"
+- No: mid-sentence em dash elaborations ("algo —que resulta interesante— porque")
+
+**English**
+- No: "delve into", "leverage" (as a verb), "navigate the complexities of", "tap into", "shed light on", "it's worth noting", "this allows us to"
+- No: mid-sentence em dash elaborations ("this is key — and often overlooked — because")
+
+**Chinese**
+- No rigid 首先/其次/再次/最后 structure for every paragraph
+- No: 值得注意的是, 综上所述, 总的来说, 毋庸置疑 — too formal, AI-default
+- Avoid overusing 此外, 然而, 因此 as paragraph openers
+
+**Japanese**
+- No rigid まず/次に/そして/最後に structure
+- Avoid overusing なお, また, さらに, したがって as sentence openers
+- Prefer short verb forms: できる not することができる, わかる not 理解することができる
+
 ### Narrative Style (applies to all languages)
 
 Narrative posts (walkthroughs, stories, investigations) follow these additional rules:

--- a/content/blog/half-life/index.es.md
+++ b/content/blog/half-life/index.es.md
@@ -34,7 +34,7 @@ D:
 
 :((( Qué acabo de hacer??
 
-Y luego empecé a defenderme. En Half-Life, los combates son un rompecabezas para resolver; no es como esos juegos donde tenés que morir para saber algo y luego reintentarlo, pasándolos a pura fuerza bruta (siempre me pregunté cómo sabés esas cosas sin morir primero). En Half-Life, realmente tenés que valorar tu vida y tratarla como lo más importante que tenés.
+Y luego empecé a defenderme. En Half-Life, los combates son un rompecabezas para resolver; no es como esos juegos donde tenés que morir para saber algo y luego reintentarlo, pasándolos a base de fuerza bruta (siempre me pregunté cómo sabés esas cosas sin morir primero). En Half-Life, realmente tenés que valorar tu vida y tratarla como lo más importante que tenés.
 
 Sos un hombre de ciencia, no un asesino. Si ves una amenaza, primero corrés para protegerte, después pensás en cómo aprovechar tus herramientas, el entorno y el conocimiento contra el enemigo. Si realmente no necesitas matar a nadie, no lo hacés, pero si lo hacés, ahora tenés un plan.
 

--- a/content/blog/half-life/index.es.md
+++ b/content/blog/half-life/index.es.md
@@ -54,7 +54,7 @@ El juego tiene algunos mensajes interesantes:
 
 <video src="/en/blog/half-life/mashup.webm" width="100%" preload autoplay muted playsinline loop></video>
 
-Vi a mucha gente con problemas para jugar Half-Life porque esperaban que el juego les dijera qué hacer, y si el juego no lo hace, ¡no hacen nada! El juego se trata de curiosidad y de probar nuevas ideas, y eso se extiende a mucho más que la historia.
+He visto a mucha gente tener problemas para jugar Half-Life porque esperan que el juego les diga qué hacer, y si el juego no lo hace, ¡no hacen nada! El juego se trata de curiosidad y de probar nuevas ideas, y eso se extiende a mucho más que la historia.
 
 El juego está lleno de mods y de una comunidad que intenta cosas raras, y Valve (la empresa detrás de Half-Life) lo permite y lo promueve, desatando mucha creatividad artística y posibilidades. Por eso tenemos muchos juegos basados en Half-Life. Siento que gran parte de eso se ha perdido, y estamos encerrados en walled gardens.
 

--- a/content/blog/half-life/index.es.md
+++ b/content/blog/half-life/index.es.md
@@ -6,7 +6,7 @@ readingTime = true
 
 ![Tren con G-Man y un científico adentro](train.jpg)
 
-Half-Life cambia la forma en que pensás sobre la vida; no es un shooter en primera persona normal. Como alguien que creció jugando Doom, la primera vez que jugué Half-Life tuve una de las realizaciones más importantes de mi infancia: no necesitas tanta habilidad si realmente pensás, y huir de los problemas es muy útil y aceptable a veces (una de las razones por las que también me encantaba jugar Resident Evil en la Play 1 en ese entonces, pero me asustaba mucho).
+Half-Life cambia la forma en que pensás sobre la vida; no es un shooter en primera persona normal. Como alguien que creció jugando Doom, la primera vez que jugué Half-Life tuve una de las revelaciones más importantes de mi infancia: no necesitas tanta habilidad si realmente pensás, y huir de los problemas es muy útil y aceptable a veces (una de las razones por las que también me encantaba jugar Resident Evil en la Play 1 en ese entonces, pero me asustaba mucho).
 
 Era un domingo soleado; tenía alrededor de 4 años, y mi hermano me dijo que vaya al local de juegos (sí, caminando físicamente) y comprara Counter-Strike (era el juego más popular en los cibers de Buenos Aires). Así que fui con mi papá. En ese momento, había 2 Counter-Strike disponibles (normal y Condition Zero), así que traje ambos a casa, inserté el primer disco en la compu, y apareció una pantalla de Half-Life.
 
@@ -34,7 +34,7 @@ D:
 
 :((( Qué acabo de hacer??
 
-Y luego empecé a defenderme. En Half-Life, los combates son un rompecabezas para resolver; no es como esos juegos donde tenés que morir para saber algo y luego reintentarlo, pasándolos con fuerza bruta (siempre me pregunté cómo sabés esas cosas sin morir primero). En Half-Life, realmente tenés que valorar tu vida y tratarla como lo más importante que tenés.
+Y luego empecé a defenderme. En Half-Life, los combates son un rompecabezas para resolver; no es como esos juegos donde tenés que morir para saber algo y luego reintentarlo, pasándolos a pura fuerza bruta (siempre me pregunté cómo sabés esas cosas sin morir primero). En Half-Life, realmente tenés que valorar tu vida y tratarla como lo más importante que tenés.
 
 Sos un hombre de ciencia, no un asesino. Si ves una amenaza, primero corrés para protegerte, después pensás en cómo aprovechar tus herramientas, el entorno y el conocimiento contra el enemigo. Si realmente no necesitas matar a nadie, no lo hacés, pero si lo hacés, ahora tenés un plan.
 
@@ -54,7 +54,7 @@ El juego tiene algunos mensajes interesantes:
 
 <video src="/en/blog/half-life/mashup.webm" width="100%" preload autoplay muted playsinline loop></video>
 
-He visto a mucha gente tener problemas para jugar Half-Life porque esperan que el juego les diga qué hacer, y si el juego no lo hace, ¡no hacen nada! El juego se trata de curiosidad y de probar nuevas ideas, y eso se extiende a mucho más que la historia.
+Vi a mucha gente con problemas para jugar Half-Life porque esperaban que el juego les dijera qué hacer, y si el juego no lo hace, ¡no hacen nada! El juego se trata de curiosidad y de probar nuevas ideas, y eso se extiende a mucho más que la historia.
 
 El juego está lleno de mods y de una comunidad que intenta cosas raras, y Valve (la empresa detrás de Half-Life) lo permite y lo promueve, desatando mucha creatividad artística y posibilidades. Por eso tenemos muchos juegos basados en Half-Life. Siento que gran parte de eso se ha perdido, y estamos encerrados en walled gardens.
 

--- a/content/blog/invertir-en-vos/index.es.md
+++ b/content/blog/invertir-en-vos/index.es.md
@@ -12,7 +12,7 @@ Estaba leyendo Twitter Finanzas y vi que le hicieron la típica pregunta de "en 
 
 Voy a explicar por qué esa idea es absurda desde múltiples puntos de vista.
 
-Soy bastante pesimista con las recomendaciones en general porque no existen como tal. "¿Invierto en esto o en aquello?", "¿qué es más seguro, Android o iOS?", "¿es mejor usar apps o webs?", "¿tengo que usar VPN?" Todas estas son preguntas que son imposibles de responder en sí; la respuesta siempre es DEPENDE. Cada persona es única, y para cada individuo la respuesta es distinta. Además para la misma persona la respuesta puede cambiar mañana. Por eso en sistemas no aprendemos respuestas, sino el arte de entender los requerimientos y llegar a las soluciones posibles.
+Soy bastante pesimista con las recomendaciones en general porque no existen como tal. "¿Invierto en esto o en aquello?", "¿qué es más seguro, Android o iOS?", "¿es mejor usar apps o webs?", "¿tengo que usar VPN?" Todas son preguntas imposibles de responder en sí; la respuesta siempre es DEPENDE. Cada persona es única, y para cada individuo la respuesta es distinta. Además para la misma persona la respuesta puede cambiar mañana. Por eso en sistemas no aprendemos respuestas, sino el arte de entender los requerimientos y llegar a las soluciones posibles.
 
 Voy a comenzar cuestionando la idea de "invertir en vos mismo" con una idea muy básica: la cantidad de conocimiento gratuito en internet es literalmente infinita. ¿Qué te impide utilizarlo? Saber cómo encontrarlo y aprovecharlo, y el hecho de que solo tenés un cerebro y 24 horas al día. ¿Cuánto dinero podés invertir en vos mismo realmente? Bastante poco.
 

--- a/content/blog/invertir-en-vos/index.es.md
+++ b/content/blog/invertir-en-vos/index.es.md
@@ -12,7 +12,7 @@ Estaba leyendo Twitter Finanzas y vi que le hicieron la típica pregunta de "en 
 
 Voy a explicar por qué esa idea es absurda desde múltiples puntos de vista.
 
-Soy bastante pesimista con las recomendaciones en general porque no existen como tal. "¿Invierto en esto o en aquello?", "¿qué es más seguro, Android o iOS?", "¿es mejor usar apps o webs?", "¿tengo que usar VPN?" Todas son preguntas imposibles de responder en sí; la respuesta siempre es DEPENDE. Cada persona es única, y para cada individuo la respuesta es distinta. Además para la misma persona la respuesta puede cambiar mañana. Por eso en sistemas no aprendemos respuestas, sino el arte de entender los requerimientos y llegar a las soluciones posibles.
+Soy bastante pesimista con las recomendaciones en general porque no existen como tal. "¿Invierto en esto o en aquello?", "¿qué es más seguro, Android o iOS?", "¿es mejor usar apps o webs?", "¿tengo que usar VPN?" Todas estas son preguntas que son imposibles de responder en sí; la respuesta siempre es DEPENDE. Cada persona es única, y para cada individuo la respuesta es distinta. Además para la misma persona la respuesta puede cambiar mañana. Por eso en sistemas no aprendemos respuestas, sino el arte de entender los requerimientos y llegar a las soluciones posibles.
 
 Voy a comenzar cuestionando la idea de "invertir en vos mismo" con una idea muy básica: la cantidad de conocimiento gratuito en internet es literalmente infinita. ¿Qué te impide utilizarlo? Saber cómo encontrarlo y aprovecharlo, y el hecho de que solo tenés un cerebro y 24 horas al día. ¿Cuánto dinero podés invertir en vos mismo realmente? Bastante poco.
 

--- a/content/blog/tronlink-wallet-recovery/index.en.md
+++ b/content/blog/tronlink-wallet-recovery/index.en.md
@@ -127,7 +127,7 @@ Injection sent. Waiting for listener...
 Listener is UP!
 ```
 
-`Listener is UP!`. It works. I've now confirmed I can get in. Now it's time to do it on the real phone, where there's no room for error.
+`Listener is UP!`. It works. I've now confirmed I can get in. Now I just need to do it on the real phone, where there's no room for error.
 
 ### Extracting the full dump
 

--- a/content/blog/tronlink-wallet-recovery/index.es.md
+++ b/content/blog/tronlink-wallet-recovery/index.es.md
@@ -127,7 +127,7 @@ Injection sent. Waiting for listener...
 Listener is UP!
 ```
 
-`Listener is UP!`. Funciona. Ya tengo confirmado que puedo entrar. Ahora toca hacerlo en el teléfono real, donde no hay margen de error.
+`Listener is UP!`. Funciona. Ya tengo confirmado que puedo entrar. Ahora falta hacerlo en el teléfono real, donde no hay margen de error.
 
 ### Extraer el dump completo
 

--- a/content/blog/tronlink-wallet-recovery/index.es.md
+++ b/content/blog/tronlink-wallet-recovery/index.es.md
@@ -114,7 +114,7 @@ Con la ayuda de Gemini toco `zygote-injection-toolkit` para arreglar un par de e
 - `--seinfo=default:targetSdkVersion=30:complete`
 
 
-Todo esto lo meto en `repro.py`. Arma el payload con el padding para Android 12+, lo inyecta vía `adb shell`, fuerza el reinicio de Settings para triggerear la lectura, y espera a que un netcat se levante en localhost. Si funciona, tenés una reverse shell con la identidad de TronLink. Si falla, limpia el setting para no dejar el teléfono en mal estado.
+Todo esto lo meto en `repro.py`, que arma el payload con el padding para Android 12+, lo inyecta vía `adb shell`, fuerza el reinicio de Settings para triggerear la lectura, y espera a que un netcat se levante en localhost. Si funciona, tenés una reverse shell con la identidad de TronLink. Si falla, limpia el setting para no dejar el teléfono en mal estado.
 
 ```bash
 $ uv run repro.py --uid 10145 --gid 10145

--- a/content/blog/tronlink-wallet-recovery/index.es.md
+++ b/content/blog/tronlink-wallet-recovery/index.es.md
@@ -114,7 +114,7 @@ Con la ayuda de Gemini toco `zygote-injection-toolkit` para arreglar un par de e
 - `--seinfo=default:targetSdkVersion=30:complete`
 
 
-Todo esto lo meto en `repro.py`, que arma el payload con el padding para Android 12+, lo inyecta vía `adb shell`, fuerza el reinicio de Settings para triggerear la lectura, y espera a que un netcat se levante en localhost. Si funciona, tenés una reverse shell con la identidad de TronLink. Si falla, limpia el setting para no dejar el teléfono en mal estado.
+Todo esto lo meto en `repro.py`. El script arma el payload con el padding para Android 12+, lo inyecta vía `adb shell`, fuerza el reinicio de Settings para triggerear la lectura, y espera a que un netcat se levante en localhost. Si funciona, tenés una reverse shell con la identidad de TronLink. Si falla, limpia el setting para no dejar el teléfono en mal estado.
 
 ```bash
 $ uv run repro.py --uid 10145 --gid 10145


### PR DESCRIPTION
- half-life: realizaciones → revelaciones (falso amigo), He visto → Vi (rioplatense), pasándolos a pura fuerza bruta
- invertir-en-vos: eliminar doble 'son'
- tronlink: repro.py. Arma → repro.py, que arma